### PR TITLE
Preserve other data fields from the original

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,37 +20,53 @@ Or install it yourself as:
 
 ## Usage
 
+This function takes two hashes of parallel membership lists (e.g.
+membership of a Legislature, and memberships of a political
+party/faction), and returns a single list of all the membership
+permuations.  Each must contain an `id`, and in the resulting hash the
+value of that key will be set according to the instructions given (e.g.
+in the example below the `id` of the `term_mems` will be set as `term`
+in the result)
+
 ```ruby
+
 term_mems = [
-  { id: '2', name: '2. Národná rada 1998-2002', start_date: '1998-09-26', end_date: '2002-09-21' }
+  { id: '1', start_date: '1998-01-01', end_date: '1999-12-31', area: 'Oldville' },
+  { id: '2', start_date: '2000-01-01', end_date: '2001-12-31', area: 'Newville' }
 ]
 
 group_mems = [
-  { name: 'Independent', id: '0', end_date: Date.new(1998, 10, 28) },
-  { id: '1', name: 'Klub ĽS-HZDS', start_date: Date.new(1998, 10, 29), end_date: Date.new(2002, 07, 15) },
-  { name: 'Independent', id: '0', start_date: Date.new(2002, 07, 16) }
+  { id: 'White Party', start_date: '1990-01-01', end_date: '1999-05-28' },
+  { id: 'Black Party', start_date: '1999-06-01' },
 ]
 
 output = CombinePopoloMemberships.combine(term: term_mems, faction_id: group_mems)
 
 output == [
-  { start_date: '1998-09-26', end_date: '1998-10-28', faction_id: '0', term: '2' },
-  { start_date: '1998-10-29', end_date: '2002-07-15', faction_id: '1', term: '2' },
-  { start_date: '2002-07-16', end_date: '2002-09-21', faction_id: '0', term: '2' }
+  { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", term: "1"},
+  { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", term: "1"},
+  { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", term: "2"}
 ] # => true
 ```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies.
+Then, run `rake test` to run the tests. You can also run `bin/console`
+for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake
+install`. To release a new version, update the version number in
+`version.rb`, and then run `bundle exec rake release`, which will create
+a git tag for the version, push git commits and tags, and push the
+`.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/combine_popolo_memberships.
-
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/everypolitician/combine_popolo_memberships.
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ group_mems = [
 output = CombinePopoloMemberships.combine(term: term_mems, faction_id: group_mems)
 
 output == [
-  { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", term: "1"},
-  { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", term: "1"},
-  { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", term: "2"}
+  { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", area: "Oldville", term: "1"},
+  { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", area: "Oldville", term: "1"},
+  { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", area: "Newville", term: "2"}
 ] # => true
 ```
 

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -20,8 +20,11 @@ module CombinePopoloMemberships
   def self.combine(h)
     into_name, into_data, from_name, from_data = h.flatten
     from_data.product(into_data).map { |a, b| overlap(a, b) }.compact.map do |h|
-      data = h.delete :_data
-      h.merge(from_name => data.first[:id], into_name => data.last[:id])
+      from, to = h.delete :_data
+      [from, to].each { |orig|
+        orig.each { |k, v| h[k] = v unless %i(id start_date end_date).include? k }
+      }
+      h.merge(from_name => from[:id], into_name => to[:id])
     end.sort_by { |h| h[:start_date].to_s }
   end
 end

--- a/lib/combine_popolo_memberships/version.rb
+++ b/lib/combine_popolo_memberships/version.rb
@@ -1,3 +1,3 @@
 module CombinePopoloMemberships
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/test/combine_popolo_memberships_test.rb
+++ b/test/combine_popolo_memberships_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'date'
 
 class CombinePopoloMembershipsTest < Minitest::Test
   def test_that_it_has_a_version_number
@@ -6,25 +7,32 @@ class CombinePopoloMembershipsTest < Minitest::Test
   end
 
   def term_mems
-    @term_mems ||= [
-      { id: '2', name: '2. Národná rada 1998-2002', start_date: '1998-09-26', end_date: '2002-09-21' }
+    [
+      { id: '1', start_date: '1998-01-01', end_date: '1999-12-31', area: 'Oldville' },
+      { id: '2', start_date: '2000-01-01', end_date: '2001-12-31', area: 'Newville' }
     ]
   end
 
   def group_mems
-    @group_mems ||= [
-      { name: 'Independent', id: '0', end_date: Date.new(1998, 10, 28) },
-      { id: '1', name: 'Klub ĽS-HZDS', start_date: Date.new(1998, 10, 29), end_date: Date.new(2002, 07, 15) },
-      { name: 'Independent', id: '0', start_date: Date.new(2002, 07, 16) }
+    [
+      { id: 'White Party', start_date: '1990-01-01', end_date: '1999-05-28' },
+      { id: 'Black Party', start_date: '1999-06-01' },
+    ]
+  end
+
+  def expected_combination
+    [
+      { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", term: "1"},
+      { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", term: "1"},
+      { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", term: "2"}
     ]
   end
 
   def test_combining_memberships
-    expected = [
-      { start_date: '1998-09-26', end_date: '1998-10-28', faction_id: '0', term: '2' },
-      { start_date: '1998-10-29', end_date: '2002-07-15', faction_id: '1', term: '2' },
-      { start_date: '2002-07-16', end_date: '2002-09-21', faction_id: '0', term: '2' }
-    ]
-    assert_equal expected, CombinePopoloMemberships.combine(term: term_mems, faction_id: group_mems)
+    assert_equal expected_combination, CombinePopoloMemberships.combine(term: term_mems, faction: group_mems)
+  end
+
+  def test_combining_in_reverse
+    assert_equal expected_combination, CombinePopoloMemberships.combine(faction: group_mems, term: term_mems)
   end
 end

--- a/test/combine_popolo_memberships_test.rb
+++ b/test/combine_popolo_memberships_test.rb
@@ -22,9 +22,9 @@ class CombinePopoloMembershipsTest < Minitest::Test
 
   def expected_combination
     [
-      { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", term: "1"},
-      { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", term: "1"},
-      { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", term: "2"}
+      { start_date: "1998-01-01", end_date: "1999-05-28", faction: "White Party", area: 'Oldville', term: "1"},
+      { start_date: "1999-06-01", end_date: "1999-12-31", faction: "Black Party", area: 'Oldville', term: "1"},
+      { start_date: "2000-01-01", end_date: "2001-12-31", faction: "Black Party", area: 'Newville', term: "2"}
     ]
   end
 


### PR DESCRIPTION
If the original data has any fields other than `id`, `start_date`, or
`end_date`, preserve them into the resulting data.
