### PR TITLE
Use external library for date handling code

### DIFF
--- a/combine_popolo_memberships.gemspec
+++ b/combine_popolo_memberships.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'date-range'
+
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest'

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -4,6 +4,8 @@ require 'date-range'
 # Takes multiple popolo membership arrays and combines them based on date.
 module CombinePopoloMemberships
   class Membership
+    attr_reader :membership_hash
+
     def initialize(membership_hash)
       @membership_hash = membership_hash
     end
@@ -25,19 +27,11 @@ module CombinePopoloMemberships
     def overlap(other)
       o = date_range.overlap(other.date_range)
       return unless o
-      to_h.merge(other.to_h).tap do |h|
+      membership_hash.merge(other.membership_hash).tap do |h|
         h[:start_date] = o.start_date
         h[:end_date] = o.end_date
       end
     end
-
-    def to_h
-      membership_hash
-    end
-
-    private
-
-    attr_reader :membership_hash
   end
 
   def self.combine(h)

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -1,30 +1,50 @@
 require 'combine_popolo_memberships/version'
+require 'date-range'
 
 # Takes multiple popolo membership arrays and combines them based on date.
 module CombinePopoloMemberships
-  def self.overlap(mem, term)
-    mS = mem[:start_date].to_s.empty? ? '0000-00-00' : mem[:start_date].to_s
-    mE = mem[:end_date].to_s.empty? ? '9999-99-99' : mem[:end_date].to_s
-    tS = term[:start_date].to_s.empty? ? '0000-00-00' : term[:start_date].to_s
-    tE = term[:end_date].to_s.empty? ? '9999-99-99' : term[:end_date].to_s
+  class Membership
+    def initialize(raw)
+      @raw = raw
+    end
 
-    return unless mS < tE && mE > tS
-    (s, e) = [mS, mE, tS, tE].sort[1, 2]
-    {
-      _data: [mem, term],
-      start_date: s == '0000-00-00' ? nil : s,
-      end_date:   e == '9999-99-99' ? nil : e
-    }
+    def start_date
+      @start_date ||= raw[:start_date].to_s.empty? ? '0000-00-00' : raw[:start_date].to_s
+    end
+
+    def end_date
+      @end_date ||= raw[:end_date].to_s.empty? ? '9999-99-99' : raw[:end_date].to_s
+    end
+
+    def date_range
+      @date_range ||= DateRange.new(start_date, end_date)
+    end
+
+    def overlap(other)
+      o = date_range.overlap(other.date_range)
+      return unless o
+      {}.merge(to_h).merge(other.to_h).tap do |h|
+        h[:start_date] = o.start_date
+        h[:end_date] = o.end_date
+      end
+    end
+
+    def to_h
+      raw
+    end
+
+    private
+
+    attr_reader :raw
   end
 
   def self.combine(h)
     into_name, into_data, from_name, from_data = h.flatten
-    from_data.product(into_data).map { |a, b| overlap(a, b) }.compact.map do |h|
-      from, to = h.delete :_data
-      [from, to].each { |orig|
-        orig.each { |k, v| h[k] = v unless %i(id start_date end_date).include? k }
-      }
+    from_data.product(into_data).map do |from, to|
+      h = Membership.new(from).overlap(Membership.new(to))
+      next unless h
+      h.delete(:id)
       h.merge(from_name => from[:id], into_name => to[:id])
-    end.sort_by { |h| h[:start_date].to_s }
+    end.compact.sort_by { |h| h[:start_date].to_s }
   end
 end

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -10,16 +10,6 @@ module CombinePopoloMemberships
       @membership_hash = membership_hash
     end
 
-    def start_date
-      @start_date ||=
-        membership_hash[:start_date].to_s.empty? ? '0000-00-00' : membership_hash[:start_date].to_s
-    end
-
-    def end_date
-      @end_date ||=
-        membership_hash[:end_date].to_s.empty? ? '9999-99-99' : membership_hash[:end_date].to_s
-    end
-
     def date_range
       @date_range ||= DateRange.new(start_date, end_date)
     end
@@ -31,6 +21,18 @@ module CombinePopoloMemberships
         h[:start_date] = o.start_date
         h[:end_date] = o.end_date
       end
+    end
+
+    private
+
+    def start_date
+      @start_date ||=
+        membership_hash[:start_date].to_s.empty? ? '0000-00-00' : membership_hash[:start_date].to_s
+    end
+
+    def end_date
+      @end_date ||=
+        membership_hash[:end_date].to_s.empty? ? '9999-99-99' : membership_hash[:end_date].to_s
     end
   end
 

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -4,16 +4,18 @@ require 'date-range'
 # Takes multiple popolo membership arrays and combines them based on date.
 module CombinePopoloMemberships
   class Membership
-    def initialize(raw)
-      @raw = raw
+    def initialize(membership_hash)
+      @membership_hash = membership_hash
     end
 
     def start_date
-      @start_date ||= raw[:start_date].to_s.empty? ? '0000-00-00' : raw[:start_date].to_s
+      @start_date ||=
+        membership_hash[:start_date].to_s.empty? ? '0000-00-00' : membership_hash[:start_date].to_s
     end
 
     def end_date
-      @end_date ||= raw[:end_date].to_s.empty? ? '9999-99-99' : raw[:end_date].to_s
+      @end_date ||=
+        membership_hash[:end_date].to_s.empty? ? '9999-99-99' : membership_hash[:end_date].to_s
     end
 
     def date_range
@@ -30,12 +32,12 @@ module CombinePopoloMemberships
     end
 
     def to_h
-      raw
+      membership_hash
     end
 
     private
 
-    attr_reader :raw
+    attr_reader :membership_hash
   end
 
   def self.combine(h)

--- a/lib/combine_popolo_memberships.rb
+++ b/lib/combine_popolo_memberships.rb
@@ -25,7 +25,7 @@ module CombinePopoloMemberships
     def overlap(other)
       o = date_range.overlap(other.date_range)
       return unless o
-      {}.merge(to_h).merge(other.to_h).tap do |h|
+      to_h.merge(other.to_h).tap do |h|
         h[:start_date] = o.start_date
         h[:end_date] = o.end_date
       end

--- a/test/membership_test.rb
+++ b/test/membership_test.rb
@@ -11,18 +11,13 @@ class MembershipTest < Minitest::Test
     membership = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
     assert_equal '0000-00-00', membership.date_range.start_date
     assert_equal '9999-99-99', membership.date_range.end_date
+    assert_equal({ start_date: nil, end_date: nil }, membership.membership_hash)
   end
 
   def test_with_empty_strings
     membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
     assert_equal '0000-00-00', membership.date_range.start_date
     assert_equal '9999-99-99', membership.date_range.end_date
-  end
-
-  def test_returns_original_membership
-    membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
     assert_equal({ start_date: '', end_date: '' }, membership.membership_hash)
-    membership2 = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
-    assert_equal({ start_date: nil, end_date: nil }, membership2.membership_hash)
   end
 end

--- a/test/membership_test.rb
+++ b/test/membership_test.rb
@@ -3,20 +3,20 @@ require 'test_helper'
 class MembershipTest < Minitest::Test
   def test_with_known_dates
     membership = CombinePopoloMemberships::Membership.new(start_date: '2015-11-27', end_date: '2015-12-31')
-    assert_equal '2015-11-27', membership.start_date
-    assert_equal '2015-12-31', membership.end_date
+    assert_equal '2015-11-27', membership.date_range.start_date
+    assert_equal '2015-12-31', membership.date_range.end_date
   end
 
   def test_with_nil
     membership = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
-    assert_equal '0000-00-00', membership.start_date
-    assert_equal '9999-99-99', membership.end_date
+    assert_equal '0000-00-00', membership.date_range.start_date
+    assert_equal '9999-99-99', membership.date_range.end_date
   end
 
   def test_with_empty_strings
     membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
-    assert_equal '0000-00-00', membership.start_date
-    assert_equal '9999-99-99', membership.end_date
+    assert_equal '0000-00-00', membership.date_range.start_date
+    assert_equal '9999-99-99', membership.date_range.end_date
   end
 
   def test_returns_original_membership

--- a/test/membership_test.rb
+++ b/test/membership_test.rb
@@ -1,16 +1,8 @@
 require 'test_helper'
 
 class MembershipTest < Minitest::Test
-  def start_date
-    '2015-11-27'
-  end
-
-  def end_date
-    '2015-12-31'
-  end
-
   def test_with_known_dates
-    membership = CombinePopoloMemberships::Membership.new(start_date: start_date, end_date: end_date)
+    membership = CombinePopoloMemberships::Membership.new(start_date: '2015-11-27', end_date: '2015-12-31')
     assert_equal '2015-11-27', membership.start_date
     assert_equal '2015-12-31', membership.end_date
   end

--- a/test/membership_test.rb
+++ b/test/membership_test.rb
@@ -29,8 +29,8 @@ class MembershipTest < Minitest::Test
 
   def test_returns_original_membership
     membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
-    assert_equal({ start_date: '', end_date: '' }, membership.to_h)
+    assert_equal({ start_date: '', end_date: '' }, membership.membership_hash)
     membership2 = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
-    assert_equal({ start_date: nil, end_date: nil }, membership2.to_h)
+    assert_equal({ start_date: nil, end_date: nil }, membership2.membership_hash)
   end
 end

--- a/test/membership_test.rb
+++ b/test/membership_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class MembershipTest < Minitest::Test
+  def start_date
+    '2015-11-27'
+  end
+
+  def end_date
+    '2015-12-31'
+  end
+
+  def test_with_known_dates
+    membership = CombinePopoloMemberships::Membership.new(start_date: start_date, end_date: end_date)
+    assert_equal '2015-11-27', membership.start_date
+    assert_equal '2015-12-31', membership.end_date
+  end
+
+  def test_with_nil
+    membership = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
+    assert_equal '0000-00-00', membership.start_date
+    assert_equal '9999-99-99', membership.end_date
+  end
+
+  def test_with_empty_strings
+    membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
+    assert_equal '0000-00-00', membership.start_date
+    assert_equal '9999-99-99', membership.end_date
+  end
+
+  def test_returns_original_membership
+    membership = CombinePopoloMemberships::Membership.new(start_date: '', end_date: '')
+    assert_equal({ start_date: '', end_date: '' }, membership.to_h)
+    membership2 = CombinePopoloMemberships::Membership.new(start_date: nil, end_date: nil)
+    assert_equal({ start_date: nil, end_date: nil }, membership2.to_h)
+  end
+end


### PR DESCRIPTION
This uses the [date_range](https://github.com/everypolitician/date_range) for handling date overlapping. I've taken this opportunity to refactor things into a `Membership` class, which encapsulates the date overlapping logic.

Fixes https://github.com/everypolitician/combine_popolo_memberships/issues/8