### PR TITLE
Add pry to test_helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'combine_popolo_memberships'
+require 'pry'
 
 require 'minitest/autorun'


### PR DESCRIPTION
This is our standard approach, it avoids the need to require it in specific test files when debugging.