### PR TITLE
Update Ruby versions Travis tests against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.0.0
-  - 2.1.7
-  - 2.2.3
-before_install: gem install bundler -v 1.10.6
+  - 2.1.10
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+before_install: gem install bundler -v 1.14.6


### PR DESCRIPTION
~~Ruby 2.0 and 2.1 are now EOL, so change the Ruby versions we're testing against to be the most recent versions of 2.2, 2.3 and 2.4, which are the current supported patch levels.~~

This updates the Ruby versions Travis tests against so that we're using the latest patch-level versions.