### PR TITLE
Add ensure-regression-tests script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,7 @@ rvm:
   - 2.3.4
   - 2.4.1
 before_install: gem install bundler -v 1.14.6
+
+script:
+  - bundle exec rake
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/master/ensure-regression-tests)


### PR DESCRIPTION
This adds the [`ensure-regression-tests`](https://github.com/everypolitician/ensure-regression-tests) script to the Travis config.

Part of https://github.com/everypolitician/everypolitician/issues/588